### PR TITLE
A tweak for the bootstrap.sh file that allows it to work on MacOS (OSX 10.8 Mountain Lion)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -20,7 +20,7 @@ if [ -e antlr-3.2/lib/libantlr3c.a ]; then
 else
 	MYPWD="$PWD"
         FLAGS64=
-        if uname -m | grep x86_64; then
+        if uname -m | grep x86_64 && ! uname | grep Darwin; then
             FLAGS64=--enable-64bit ;
         fi
 	tar -zxf libantlr3c-3.2.tar.gz && \


### PR DESCRIPTION
MacOS OSX Mountain Lion (10.8.2) with XCode 4.5.2 doesn't like the libantlr3.a file if --enable-64bit is passed to configure.
