### PR TITLE
Extended README and miscellaneous code cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pbj
 antlr-3.*
 libantlr3c-*
 output
+*~

--- a/ProtoJSParseUtil.cpp
+++ b/ProtoJSParseUtil.cpp
@@ -1439,9 +1439,6 @@ void printEnum(pProtoJSParser ctx, int offset, pANTLR3_STRING id, pANTLR3_LIST e
     }
 }
 void defineEnum(pProtoJSParser ctx, pANTLR3_STRING id, pANTLR3_LIST enumValues) {
-    pANTLR3_STRING messageName=NULL;
-    if (SCOPE_SIZE(message))
-        messageName=(SCOPE_TOP(message))->messageName;
     int i,*maxval=(int*)malloc(sizeof(int));
     *maxval=0;
     if (SCOPE_TOP(Symbols) == NULL) return;
@@ -1459,9 +1456,6 @@ void defineEnum(pProtoJSParser ctx, pANTLR3_STRING id, pANTLR3_LIST enumValues) 
     SCOPE_TOP(Symbols)->enum_sizes->put(SCOPE_TOP(Symbols)->enum_sizes,id->chars,maxval,&free);        
 }
 void defineEnumValue(pProtoJSParser ctx, pANTLR3_STRING enumName, pANTLR3_LIST enumValues, pANTLR3_STRING id, pANTLR3_STRING value) {
-    pANTLR3_STRING messageName=NULL;
-    if (SCOPE_SIZE(message))
-        messageName=(SCOPE_TOP(message))->messageName;
     if (SCOPE_TOP(Symbols) == NULL) return;
     SCOPE_TOP(Symbols)->enum_values->put(SCOPE_TOP(Symbols)->enum_values, id->chars, value, NULL);
     enumValues->put(enumValues,enumValues->size(enumValues),id,stringFree);
@@ -1469,9 +1463,6 @@ void defineEnumValue(pProtoJSParser ctx, pANTLR3_STRING enumName, pANTLR3_LIST e
 
 }
 void defineFlag(pProtoJSParser ctx, pANTLR3_STRING id, pANTLR3_LIST flagValues, unsigned int flagBits) {
-    pANTLR3_STRING messageName=NULL;
-    if (SCOPE_SIZE(message))
-        messageName=(SCOPE_TOP(message))->messageName;
     unsigned int* bits=(unsigned int *)malloc(sizeof(unsigned int));
     *bits=flagBits;
     if (SCOPE_TOP(Symbols) == NULL) return;
@@ -1500,9 +1491,6 @@ void defineFlag(pProtoJSParser ctx, pANTLR3_STRING id, pANTLR3_LIST flagValues, 
 }
 
 void defineFlagValue(pProtoJSParser ctx, pANTLR3_STRING flagName, pANTLR3_LIST flagValues, pANTLR3_STRING id, pANTLR3_STRING value) {
-    pANTLR3_STRING messageName=NULL;
-    if (SCOPE_SIZE(message))
-        messageName=(SCOPE_TOP(message))->messageName;
     if (SCOPE_TOP(Symbols) == NULL) return;//FIXME
     SCOPE_TOP(Symbols)->flag_values->put(SCOPE_TOP(Symbols)->flag_values, id->chars, id, NULL);
     flagValues->put(flagValues,flagValues->size(flagValues),id,stringFree);

--- a/README
+++ b/README
@@ -37,6 +37,15 @@ protocol/. You can also run the pbj file with "pbj input.proto output.proto"
 
 If you want to build a directory full of protocol files, run it with "make INPUTDIR=/path/to/protocol". You can optionally specify OUTPUTDIR if you don't want them to go to output.
 
+==== Building protojs (Ubuntu style):
+
+Download ANTLR Java runtime and C runtime libraries. A java interpreter is
+assumed
+
+    curl http://www.antlr.org/download/antlr-3.2.jar > antlr-3.2.jar
+    sudo apt-get install libantlr3c-dev
+    make
+
 ==== Using the javascript library:
 
 The javascript library is intended to be as similar as possible to python

--- a/main.cpp
+++ b/main.cpp
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
     pANTLR3_INPUT_STREAM input=NULL;
     pProtoJSLexer lxr;
     pANTLR3_COMMON_TOKEN_STREAM tstream;
-    pProtoJSParser psr,ctx;
+    pProtoJSParser psr;
     ProtoJSParser_protocol_return     pbjAST;
     if (argc < 2 || argv[1] == NULL)
         filename = (pANTLR3_UINT8)"./input";


### PR DESCRIPTION
- `README` with Ubuntu build instructions
- `.gitignore` will now ignore temporary files
- Unneccessary idioms removed from `ProtoJSParseUtil.cpp`
- Removed declared but not defined variable from `main.cpp`
