### PR TITLE
Minor change to bootstrap script for building on Darwin

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -20,7 +20,7 @@ if [ -e antlr-3.2/lib/libantlr3c.a ]; then
 else
 	MYPWD="$PWD"
         FLAGS64=
-        if uname -m | grep x86_64 && ! uname | grep Darwin; then
+        if uname -m | grep x86_64 || uname | grep Darwin; then
             FLAGS64=--enable-64bit ;
         fi
 	tar -zxf libantlr3c-3.2.tar.gz && \


### PR DESCRIPTION
Looks like the --enable-64bit flag for antlr is needed for Darwin.  This is on OS X 10.8.4 / Xcode 4.6.2.

Otherwise, the following linker errors occur:

```
ld: warning: ignoring file antlr-3.2/lib/libantlr3c.a, file was built for archive which is not the architecture being linked (x86_64): antlr-3.2/lib/libantlr3c.a
Undefined symbols for architecture x86_64:
  "_ANTLR3_TREE_ADAPTORNew", referenced from:
      _ProtoJSParserNewSSD in ProtoJSParser.o
  "_antlr3AsciiFileStreamNew", referenced from:
      parseProto(char const*, char const*, char const*, char const*, char**, ANTLR3_HASH_TABLE_struct*, bool, ProtoJSParser_protocol_return_struct*, ProtoJSLexer_Ctx_struct**, ProtoJSParser_Ctx_struct**, ANTLR3_COMMON_TOKEN_STREAM_struct**, ANTLR3_INPUT_STREAM_struct**)in cctWu4tT.o
  "_antlr3CommonTokenStreamSourceNew", referenced from:
      parseProto(char const*, char const*, char const*, char const*, char**, ANTLR3_HASH_TABLE_struct*, bool, ProtoJSParser_protocol_return_struct*, ProtoJSLexer_Ctx_struct**, ProtoJSParser_Ctx_struct**, ANTLR3_COMMON_TOKEN_STREAM_struct**, ANTLR3_INPUT_STREAM_struct**)in cctWu4tT.o
  "_antlr3CommonTreeNodeStreamNewTree", referenced from:
      _main in cctWu4tT.o
  "_antlr3HashTableNew", referenced from:
      _main in cctWu4tT.o
      _initSymbolTable in ProtoJSParseUtil.o
      _initNameSpace in ProtoJSParseUtil.o
  "_antlr3LexerNewStream", referenced from:
      _ProtoJSLexerNewSSD in ProtoJSLexer.o
  "_antlr3ListNew", referenced from:
      _enum_def in ProtoJSParser.o
      _flags_def in ProtoJSParser.o
      _initSymbolTable in ProtoJSParseUtil.o
      _initNameSpace in ProtoJSParseUtil.o
  "_antlr3ParserNewStream", referenced from:
      _ProtoJSParserNewSSD in ProtoJSParser.o
  "_antlr3RewriteRuleSubtreeStreamNewAE", referenced from:
      _protocol in ProtoJSParser.o
      _package in ProtoJSParser.o
      _service in ProtoJSParser.o
      _message in ProtoJSParser.o
      _newline_message_element in ProtoJSParser.o
      _extensions in ProtoJSParser.o
      _reservations in ProtoJSParser.o
      ...
  "_antlr3RewriteRuleSubtreeStreamNewAEE", referenced from:
      _protocol in ProtoJSParser.o
      _pbj_header in ProtoJSParser.o
      _package in ProtoJSParser.o
      _importrule in ProtoJSParser.o
      _service in ProtoJSParser.o
      _message in ProtoJSParser.o
      _newline_message_element in ProtoJSParser.o
      ...
  "_antlr3RewriteRuleTOKENStreamNewAE", referenced from:
      _pbj_header in ProtoJSParser.o
      _package in ProtoJSParser.o
      _importrule in ProtoJSParser.o
      _service in ProtoJSParser.o
      _message in ProtoJSParser.o
      _extensions in ProtoJSParser.o
      _reservations in ProtoJSParser.o
      ...
  "_antlr3StackNew", referenced from:
      _ProtoJSParserNewSSD in ProtoJSParser.o
  "_antlr3VectorFactoryNew", referenced from:
      _ProtoJSParserNewSSD in ProtoJSParser.o
  "_antlr3dfapredict", referenced from:
      _cdfa14 in ProtoJSLexer.o
      _cdfa26 in ProtoJSLexer.o
  "_antlr3dfaspecialStateTransition", referenced from:
      _cdfa14 in ProtoJSLexer.o
  "_antlr3dfaspecialTransition", referenced from:
      _cdfa14 in ProtoJSLexer.o
      _cdfa26 in ProtoJSLexer.o
ld: symbol(s) not found for architecture x86_64
collect2: ld returned 1 exit status
ld: warning: ignoring file antlr-3.2/lib/libantlr3c.a, file was built for archive which is not the architecture being linked (x86_64): antlr-3.2/lib/libantlr3c.a
Undefined symbols for architecture x86_64:
  "_ANTLR3_TREE_ADAPTORNew", referenced from:
      _ProtoJSParserNewSSD in ProtoJSParser.o
  "_antlr3AsciiFileStreamNew", referenced from:
      parseProto(char const*, char const*, char const*, char const*, char**, ANTLR3_HASH_TABLE_struct*, bool, ProtoJSParser_protocol_return_struct*, ProtoJSLexer_Ctx_struct**, ProtoJSParser_Ctx_struct**, ANTLR3_COMMON_TOKEN_STREAM_struct**, ANTLR3_INPUT_STREAM_struct**)in cc4JosFy.o
  "_antlr3CommonTokenStreamSourceNew", referenced from:
      parseProto(char const*, char const*, char const*, char const*, char**, ANTLR3_HASH_TABLE_struct*, bool, ProtoJSParser_protocol_return_struct*, ProtoJSLexer_Ctx_struct**, ProtoJSParser_Ctx_struct**, ANTLR3_COMMON_TOKEN_STREAM_struct**, ANTLR3_INPUT_STREAM_struct**)in cc4JosFy.o
  "_antlr3CommonTreeNodeStreamNewTree", referenced from:
      _main in cc4JosFy.o
  "_antlr3HashTableNew", referenced from:
      _main in cc4JosFy.o
      _initSymbolTable in ProtoJSParseUtil.o
      _initNameSpace in ProtoJSParseUtil.o
  "_antlr3LexerNewStream", referenced from:
      _ProtoJSLexerNewSSD in ProtoJSLexer.o
  "_antlr3ListNew", referenced from:
      _enum_def in ProtoJSParser.o
      _flags_def in ProtoJSParser.o
      _initSymbolTable in ProtoJSParseUtil.o
      _initNameSpace in ProtoJSParseUtil.o
  "_antlr3ParserNewStream", referenced from:
      _ProtoJSParserNewSSD in ProtoJSParser.o
  "_antlr3RewriteRuleSubtreeStreamNewAE", referenced from:
      _protocol in ProtoJSParser.o
      _package in ProtoJSParser.o
      _service in ProtoJSParser.o
      _message in ProtoJSParser.o
      _newline_message_element in ProtoJSParser.o
      _extensions in ProtoJSParser.o
      _reservations in ProtoJSParser.o
      ...
  "_antlr3RewriteRuleSubtreeStreamNewAEE", referenced from:
      _protocol in ProtoJSParser.o
      _pbj_header in ProtoJSParser.o
      _package in ProtoJSParser.o
      _importrule in ProtoJSParser.o
      _service in ProtoJSParser.o
      _message in ProtoJSParser.o
      _newline_message_element in ProtoJSParser.o
      ...
  "_antlr3RewriteRuleTOKENStreamNewAE", referenced from:
      _pbj_header in ProtoJSParser.o
      _package in ProtoJSParser.o
      _importrule in ProtoJSParser.o
      _service in ProtoJSParser.o
      _message in ProtoJSParser.o
      _extensions in ProtoJSParser.o
      _reservations in ProtoJSParser.o
      ...
  "_antlr3StackNew", referenced from:
      _ProtoJSParserNewSSD in ProtoJSParser.o
  "_antlr3VectorFactoryNew", referenced from:
      _ProtoJSParserNewSSD in ProtoJSParser.o
  "_antlr3dfapredict", referenced from:
      _cdfa14 in ProtoJSLexer.o
      _cdfa26 in ProtoJSLexer.o
  "_antlr3dfaspecialStateTransition", referenced from:
      _cdfa14 in ProtoJSLexer.o
  "_antlr3dfaspecialTransition", referenced from:
      _cdfa14 in ProtoJSLexer.o
      _cdfa26 in ProtoJSLexer.o
ld: symbol(s) not found for architecture x86_64
```
