### PR TITLE
Added a bower.json file so this can be published in bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,16 @@
+{
+  "name": "protojs",
+  "description": "Protojs is a BSD-licensed protocol buffer library written in JavaScript",
+  "keywords": ["protobuf", "protocol", "buffers" "protojs"],
+  "version": "2.3.0",
+  "main": "protobuf.js",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "homepage": "http://sirikata.com/",
+  "license": "BSD"
+}


### PR DESCRIPTION
It would be wonderful to be able to include protobuf.js in a project using [bower](http://bower.io/), which is a package manager for front-end components.

I've taken the liberty of packaging this repo up as a bower package so that it can be published.

The package can then be registered with the following command:

``` bash
bower register protojs git@github.com:sirikata/protojs.git
```
